### PR TITLE
Add LocalAssetCollector#full_file_path for retrieving file location

### DIFF
--- a/lib/s3_asset_deploy/local_asset_collector.rb
+++ b/lib/s3_asset_deploy/local_asset_collector.rb
@@ -2,4 +2,8 @@ class S3AssetDeploy::LocalAssetCollector
   def local_asset_paths
     []
   end
+
+  def full_file_path(asset_path)
+    asset_path
+  end
 end

--- a/lib/s3_asset_deploy/manager.rb
+++ b/lib/s3_asset_deploy/manager.rb
@@ -70,7 +70,7 @@ class S3AssetDeploy::Manager
 
   # TODO: consider reduced redundancy
   def upload_asset(asset_path)
-    file_handle = File.open("#{public_path}/#{asset_path}")
+    file_handle = File.open(local_asset_collector.full_file_path(asset_path))
 
     asset = {
       bucket: bucket_name,
@@ -93,7 +93,7 @@ class S3AssetDeploy::Manager
     verify_no_duplicate_assets!
 
     local_assets_to_upload.each do |asset_path|
-      next unless File.file? "#{public_path}/#{asset_path}"
+      next unless File.file?(local_asset_collector.full_file_path(asset_path))
       log "Uploading #{asset_path}..."
       upload_asset(asset_path) unless dry_run
     end

--- a/lib/s3_asset_deploy/rails_local_asset_collector.rb
+++ b/lib/s3_asset_deploy/rails_local_asset_collector.rb
@@ -22,6 +22,10 @@ class S3AssetDeploy::RailsLocalAssetCollector < S3AssetDeploy::LocalAssetCollect
     end
   end
 
+  def full_file_path(asset_path)
+    "#{public_path}/#{asset_path}"
+  end
+
   private
 
   def assets_prefix


### PR DESCRIPTION
I forgot that we were using `public_path` in the manager before #1. This adds `S3AssetDeploy::LocalAssetCollector#full_file_path` so that the manager can query the collector for the full file path.