### PR TITLE
Cache remote assets to avoid unnecessary S3 requests [Issue #8]

### DIFF
--- a/lib/s3_asset_deploy/manager.rb
+++ b/lib/s3_asset_deploy/manager.rb
@@ -61,6 +61,7 @@ class S3AssetDeploy::Manager
     end
 
     removal_manifest.save unless dry_run
+    remote_asset_collector.clear_cache
     uploaded_assets
   end
 
@@ -130,6 +131,7 @@ class S3AssetDeploy::Manager
       removal_manifest.save
     end
 
+    remote_asset_collector.clear_cache
     s3_keys_to_delete
   end
 

--- a/lib/s3_asset_deploy/remote_asset_collector.rb
+++ b/lib/s3_asset_deploy/remote_asset_collector.rb
@@ -21,7 +21,7 @@ class S3AssetDeploy::RemoteAssetCollector
   end
 
   def assets
-    s3.list_objects_v2(bucket: bucket_name).each_with_object([]) do |response, array|
+    @assets ||= s3.list_objects_v2(bucket: bucket_name).each_with_object([]) do |response, array|
       remote_assets = response
         .contents
         .reject { |obj| obj.key == S3AssetDeploy::RemovalManifest::PATH }
@@ -31,6 +31,10 @@ class S3AssetDeploy::RemoteAssetCollector
 
       array.concat(remote_assets)
     end
+  end
+
+  def clear_cache
+    @assets = nil
   end
 
   def asset_paths


### PR DESCRIPTION
This avoids unnecessary requests to S3 to fetch remote assets by memoizing them in `RemoteAssetCollector`. Since the remote assets that exist on S3 can change after uploading or cleaning, we are clearing the cache after these operations.