### PR TITLE
Move generic methods for LocalAsset into base class

### DIFF
--- a/lib/s3_asset_deploy/local_asset.rb
+++ b/lib/s3_asset_deploy/local_asset.rb
@@ -20,7 +20,7 @@ class S3AssetDeploy::LocalAsset
   end
 
   def full_path
-    File.join(public_path, path)
+    File.join(ENV["PWD"], "public", path)
   end
 
   def mime_type
@@ -33,11 +33,5 @@ class S3AssetDeploy::LocalAsset
 
   def to_s
     path
-  end
-
-  protected
-
-  def public_path
-    ::Rails.public_path
   end
 end

--- a/lib/s3_asset_deploy/rails_local_asset.rb
+++ b/lib/s3_asset_deploy/rails_local_asset.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "s3_asset_deploy/local_asset"
+
+class S3AssetDeploy::RailsLocalAsset < S3AssetDeploy::LocalAsset
+  attr_reader :path
+
+  def full_path
+    File.join(public_path, path)
+  end
+
+  protected
+
+  def public_path
+    ::Rails.public_path
+  end
+end

--- a/lib/s3_asset_deploy/rails_local_asset_collector.rb
+++ b/lib/s3_asset_deploy/rails_local_asset_collector.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "s3_asset_deploy/local_asset"
+require "s3_asset_deploy/rails_local_asset"
 require "s3_asset_deploy/local_asset_collector"
 
 class S3AssetDeploy::RailsLocalAssetCollector < S3AssetDeploy::LocalAssetCollector
@@ -14,7 +14,7 @@ class S3AssetDeploy::RailsLocalAssetCollector < S3AssetDeploy::LocalAssetCollect
       ::ActionView::Base.assets_manifest.dir
     )
     manifest.assets.values.map do |f|
-      S3AssetDeploy::LocalAsset.new(
+      S3AssetDeploy::RailsLocalAsset.new(
         File.join(assets_prefix, f),
         remove_fingerprint: @remove_fingerprint
       )
@@ -30,7 +30,7 @@ class S3AssetDeploy::RailsLocalAssetCollector < S3AssetDeploy::LocalAssetCollect
       Dir[File.join(packs_dir, "/**/**")]
         .select { |path| File.file?(path) }
         .reject { |path| path.ends_with?(".gz") || path.ends_with?("manifest.json") }
-        .map { |path| S3AssetDeploy::LocalAsset.new(path, remove_fingerprint: @remove_fingerprint) }
+        .map { |path| S3AssetDeploy::RailsLocalAsset.new(path, remove_fingerprint: @remove_fingerprint) }
     end
   end
 

--- a/spec/manager_spec.rb
+++ b/spec/manager_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe S3AssetDeploy::Manager do
 
   describe "#upload" do
     before { allow(File).to receive(:file?) { true } }
-    before { allow_any_instance_of(S3AssetDeploy::LocalAsset).to receive(:public_path) { "" } }
 
     it "uploads new assets" do
       expect_instance_of_remote_asset_collector_to_receive_assets(


### PR DESCRIPTION
This allows others to customize local asset collection more easily by inheriting from LocalAsset, which does not have any rails specific logic.