### PR TITLE
Change RemovalManifest to perform put_object only if @manifest has changed [Issue #20]

### DIFF
--- a/lib/s3_asset_deploy/removal_manifest.rb
+++ b/lib/s3_asset_deploy/removal_manifest.rb
@@ -8,6 +8,7 @@ class S3AssetDeploy::RemovalManifest
   def initialize(bucket_name, s3_client_options: {})
     @bucket_name = bucket_name
     @loaded = false
+    @changed = false
     @manifest = {}
     @s3_client_options = {
       region: "us-east-1",
@@ -32,8 +33,14 @@ class S3AssetDeploy::RemovalManifest
     @loaded
   end
 
+  def changed?
+    @changed
+  end
+
   def save
-    return unless loaded?
+    return false unless loaded?
+    return true unless changed?
+
     s3.put_object({
       bucket: bucket_name,
       key: PATH,
@@ -41,6 +48,10 @@ class S3AssetDeploy::RemovalManifest
       acl: "private",
       content_type: "application/json"
     })
+
+    @changed = false
+
+    true
   end
 
   def keys
@@ -49,6 +60,7 @@ class S3AssetDeploy::RemovalManifest
 
   def delete(key)
     return unless loaded?
+    @changed = true
     @manifest.delete(key)
   end
 
@@ -58,6 +70,7 @@ class S3AssetDeploy::RemovalManifest
 
   def []=(key, value)
     return unless loaded?
+    @changed = true
     @manifest[key] = value
   end
 

--- a/spec/removal_manifest_spec.rb
+++ b/spec/removal_manifest_spec.rb
@@ -20,9 +20,65 @@ RSpec.describe S3AssetDeploy::RemovalManifest do
     end
   end
 
-  let(:s3_client_instance) { removal_manifest_s3_client.new }
+  let(:s3_client_instance) { s3_client.new }
 
   before { allow_any_instance_of(S3AssetDeploy::RemovalManifest).to receive(:s3) { s3_client_instance } }
+
+  describe "#changed?" do
+    let(:s3_client_instance) do
+      s3_client.new do
+        {
+          "assets/file-2-34567.jpg" => (Time.now - 172801).utc.iso8601,
+          "assets/file-3-9876666.jpg" => (Time.now - 172799).utc.iso8601
+        }
+      end
+    end
+
+    it "is false after initializing" do
+      expect(subject.changed?).to eq(false)
+    end
+
+    it "is true after setting an attribute" do
+      expect(subject.changed?).to eq(false)
+      subject.load
+      expect(subject.changed?).to eq(false)
+      subject["myfile"] = Time.now.utc.iso8601
+      expect(subject.changed?).to eq(true)
+    end
+
+    it "is true after deleting an attribute" do
+      expect(subject.changed?).to eq(false)
+      subject.load
+      expect(subject.changed?).to eq(false)
+      subject.delete("assets/file-2-34567.jpg")
+      expect(subject.changed?).to eq(true)
+    end
+
+    it "is false after saving" do
+      expect(subject.changed?).to eq(false)
+      subject.load
+      expect(subject.changed?).to eq(false)
+      subject.delete("assets/file-2-34567.jpg")
+      expect(subject.changed?).to eq(true)
+      subject.save
+      expect(subject.changed?).to eq(false)
+    end
+  end
+
+  describe "#save" do
+    it "does not make put_object request to S3 when manifest has not changed" do
+      subject.load
+      expect(s3_client_instance).to_not receive(:put_object)
+      expect(subject.save)
+    end
+
+    it "does makes put_object request to S3 when manifest has changed" do
+      subject.load
+      subject["myfile"] = Time.now.utc.iso8601
+      expect(s3_client_instance).to receive(:put_object)
+      expect(subject.save)
+    end
+  end
 
   describe "#load"  do
     let(:s3_client_instance) do


### PR DESCRIPTION
This PR adjusts `RemovalManifest` such that updates to the manifest are tracked via a boolean flag. We can therefore avoid a `put_object` request on the manifest if it hasn't changed, which is likely to be most of the time.