### PR TITLE
Remove default `acl` setting when uploading assets to bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
 
+## [v1.0.0](https://github.com/Loomly/s3_asset_deploy/compare/v0.1.1...v1.0.0) - 2021-05-13
+### Breaking Changes
+- Remove default `acl` setting when uploading assets to bucket - [PR #25](https://github.com/Loomly/s3_asset_deploy/pull/25)
+
 ## [v0.1.1](https://github.com/Loomly/s3_asset_deploy/compare/v0.1.0...v0.1.1) - 2021-03-22
 - Fix bug in AssetHelper.remove_fingerprint referencing asset_path - [4f370ad](https://github.com/Loomly/s3_asset_deploy/commit/4f370ad9c0c1c274acb9b1d8585b878f47020277)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    s3_asset_deploy (0.1.1)
+    s3_asset_deploy (1.0.0)
       aws-sdk-s3 (~> 1.0)
       mime-types (~> 3.0)
 

--- a/lib/s3_asset_deploy/manager.rb
+++ b/lib/s3_asset_deploy/manager.rb
@@ -168,7 +168,6 @@ class S3AssetDeploy::Manager
       bucket: bucket_name,
       key: asset.path,
       body: file_handle,
-      acl: "public-read",
       content_type: asset.mime_type,
       cache_control: "public, max-age=31536000"
     }.merge(@upload_options)

--- a/lib/s3_asset_deploy/version.rb
+++ b/lib/s3_asset_deploy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module S3AssetDeploy
-  VERSION = "0.1.1"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
It's better to use the AWS default for object `acl`, which defaults to private. This can be overridden to `public-read` if need be by passing in `upload_options` to the manager.