### PR TITLE
Batch delete API calls with max 1000 keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in s3_asset_deploy.gemspec
 gemspec
+
+gem "nokogiri"

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in s3_asset_deploy.gemspec
 gemspec
-
-gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  nokogiri
+  nokogiri (~> 1.13)
   pry (~> 0.13)
   pry-byebug (~> 3.9)
   rake (~> 13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,12 +32,17 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
+    mini_portile2 (2.8.0)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    racc (1.6.0)
     rake (13.0.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -60,6 +65,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  nokogiri
   pry (~> 0.13)
   pry-byebug (~> 3.9)
   rake (~> 13.0)
@@ -69,4 +75,4 @@ DEPENDENCIES
   timecop (~> 0.9)
 
 BUNDLED WITH
-   2.2.7
+   2.2.32

--- a/lib/s3_asset_deploy/manager.rb
+++ b/lib/s3_asset_deploy/manager.rb
@@ -193,10 +193,12 @@ class S3AssetDeploy::Manager
 
   def delete_objects(keys = [])
     return if keys.empty?
-    s3.delete_objects(
-      bucket: bucket_name,
-      delete: { objects: keys.map { |key| { key: key }} }
-    )
+    keys.each_slice(1000) do |key_slice|
+      s3.delete_objects(
+        bucket: bucket_name,
+        delete: { objects: key_slice.map { |key| { key: key }} }
+      )
+    end
   end
 
   def log(msg)

--- a/s3_asset_deploy.gemspec
+++ b/s3_asset_deploy.gemspec
@@ -36,6 +36,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug", "~> 3.9"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4"
 
+  # Required for aws-sdk-ruby.
+  # See https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb#L74
+  spec.add_development_dependency "nokogiri", "~> 1.13"
+
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html
 end


### PR DESCRIPTION
## Brief Summary

API calls to AWS S3 via the the `#delete_objects` method will fail when attempting to delete more than 1000 keys with the following error:

> Aws::S3::Errors::MalformedXML: The XML you provided was not well-formed or did not validate against our published schema

This update batches API calls such that we are never deleting more than 1000 keys at a time.