### PR TITLE
Remove acl specification for RemovalManifest#save

### DIFF
--- a/lib/s3_asset_deploy/removal_manifest.rb
+++ b/lib/s3_asset_deploy/removal_manifest.rb
@@ -45,7 +45,6 @@ class S3AssetDeploy::RemovalManifest
       bucket: bucket_name,
       key: PATH,
       body: @manifest.to_json,
-      acl: "private",
       content_type: "application/json"
     })
 


### PR DESCRIPTION
There's no need to set `acl` on the removal manifest since bucket policies should be used.