### PR TITLE
The 2nd argument passed into ::Sprockets::Manifest should be a filename

### DIFF
--- a/lib/s3_asset_deploy/rails_local_asset_collector.rb
+++ b/lib/s3_asset_deploy/rails_local_asset_collector.rb
@@ -11,7 +11,7 @@ class S3AssetDeploy::RailsLocalAssetCollector < S3AssetDeploy::LocalAssetCollect
   def assets_from_manifest
     manifest = ::Sprockets::Manifest.new(
       ::ActionView::Base.assets_manifest.environment,
-      ::ActionView::Base.assets_manifest.dir
+      ::ActionView::Base.assets_manifest.filename
     )
     manifest.assets.values.map do |f|
       S3AssetDeploy::RailsLocalAsset.new(


### PR DESCRIPTION
::Sprockets::Manifest expects the manifest filename as the 2nd argument, not a directory. ( Source: https://github.com/rails/sprockets/blob/main/lib/sprockets/manifest.rb )

In most cases, these are in the same location, so it doesn't matter. However, specifying `.dir` instead of `.filename` causes problems in cases where the sprockets manifest file was stored in a different location than the asset directory, which can be done in rails by setting `config.assets.manifest = 'full-path-to-manifest.json'`